### PR TITLE
Get rid of floating points instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,10 +454,11 @@ dependencies = [
  "pink-ethabi",
  "pink-extension",
  "pink-extension-runtime",
+ "pink-json 0.4.0 (git+https://github.com/Phala-Network/pink-json.git?branch=pink)",
  "pink-web3",
  "primitive-types",
  "scale-info",
- "serde_json",
+ "serde",
 ]
 
 [[package]]
@@ -1649,6 +1650,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pink-json"
+version = "0.4.0"
+source = "git+https://github.com/Phala-Network/pink-json.git?branch=pink#ff1be4b26ae409b8efeb08bf2e6df9e983bf7b3b"
+dependencies = [
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "pink-web3"
 version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1664,7 +1674,7 @@ dependencies = [
  "pink-erased-serde",
  "pink-ethabi",
  "pink-extension",
- "pink-json",
+ "pink-json 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp",
  "serde",
  "tiny-keccak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,13 @@ phat_offchain_rollup = { path = "../../phat-stateful-rollup/phat/rollup", defaul
 #abi = { git = "https://github.com/SaaS3-Foundation/abi.git" }
 abi = { path = "../abi" }
 
-serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+serde = { version = "1", default-features = false, features = ["derive"] }
+
+[dependencies.pink-json]
+git = "https://github.com/Phala-Network/pink-json.git"
+branch = "pink"
+default-features = false
+features = ["de-number-as-str"]
 
 [dev-dependencies]
 dotenvy = "0.15"
@@ -60,6 +66,8 @@ std = [
     "pink-extension/std",
     "pink-web3/std",
     "phat_offchain_rollup/std",
+    "pink-json/std",
+    "serde/std",
 ]
 ink-as-dependency = []
 [patch.crates-io]


### PR DESCRIPTION
The ink contract runtime doesn't allow floating point instructions in the wasm binary. However, using serde_json usually brings the float into the contract. We have a fork of `serde-json-core` called [`pink-json`](https://github.com/Phala-Network/pink-json.git) that does its best to avoid including floating points.